### PR TITLE
Fixed service setup for udhcpc

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,7 +574,7 @@ runit documentation says about making dependencies.
 The very last thing we will do is provide our system with a network connection.
 ```bash
 $ mkdir -p /etc/init.d/udhcpc
-$ vi /etc/init.d/udhcpc
+$ vi /etc/init.d/udhcpc/run
 $ cat /etc/init.d/udhcpc
 #!/bin/sh
 exec udhcpc -f -S


### PR DESCRIPTION
Line 577 of the README (build instructions) left off the "run" file from the vi target (previously it is targeting the folder).  Added "/run" to the line to correct it.